### PR TITLE
fix(deps): allow studio v5 in peer deps ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@sanity/ui": "^3",
     "@sanity/ui-workshop": "^3",
     "react": "^18.3 || ^19",
-    "sanity": "^4",
+    "sanity": "^4 || ^5.0.0",
     "styled-components": "^6.1"
   },
   "repository": {


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.